### PR TITLE
fix seeking by allowing decimals in range

### DIFF
--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -393,8 +393,8 @@ export class LottiePlayer extends LitElement {
       return;
     }
 
-    // Extract frame number from either number or percentage value
-    const matches = value.toString().match(/^([0-9]+)(%?)$/);
+    // Extract frame number from either decimal or percentage value
+    const matches = value.toString().match(/^([0-9]+\.?[0-9]+)(%?)$/);
     if (!matches) {
       return;
     }
@@ -635,7 +635,7 @@ export class LottiePlayer extends LitElement {
           class="seeker"
           type="range"
           min="0"
-          step="1"
+          step="any"
           max="100"
           .value=${this.seeker}
           @input=${this._handleSeekChange}


### PR DESCRIPTION
The seeker input ends up being a decimal, rather than an integer (despite the step being "1"). So the regex checks set in place for integers fail. And seeking isn't made possible

This simple fix changes the regex to allow decimals, which fixes the seeking issue. I've also changed the step size of the element to be "any", as it's value isn't an integer