### PR TITLE
fix(player): add isConnected check to disconnectedCallback

### DIFF
--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -484,6 +484,9 @@ export class LottiePlayer extends LitElement {
    * Cleanup on component destroy.
    */
   public disconnectedCallback(): void {
+    // Don't clean up if node is still connected to the context (i.e. this is a move).
+    if (this.isConnected) return;
+
     // Remove intersection observer for detecting component being out-of-view.
     if (this._io) {
       this._io.disconnect();


### PR DESCRIPTION
Added the `isConnected` check (as per the [documentation](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks)) to the `disconnectedCallback`, to avoid clean-up in cases where the node was not removed, but moved (like `insertBefore` and similar).

This is a fix for issue #152 