### PR TITLE
feat(a11y): Add background attribut as CSS var

### DIFF
--- a/src/lottie-player.styles.ts
+++ b/src/lottie-player.styles.ts
@@ -10,6 +10,7 @@ export default css`
   }
 
   :host {
+	--lottie-player-background-color: transparent;
     --lottie-player-toolbar-height: 35px;
     --lottie-player-toolbar-background-color: transparent;
     --lottie-player-toolbar-icon-color: #999;
@@ -24,7 +25,7 @@ export default css`
     height: 100%;
   }
 
-  .main {
+  .animation-wrapper {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -34,8 +35,16 @@ export default css`
   .animation {
     width: 100%;
     height: 100%;
-    display: flex;
+    display: flex;	background-color:var(--lottie-player-background-color);																				
   }
+  
+  .animation svg{
+	width: 100%;
+    height: 100%;
+    transform: translate3d(0px, 0px, 0px);
+	content-visibility: visible;
+ }
+  
   .animation.controls {
     height: calc(100% - 35px);
   }
@@ -51,6 +60,7 @@ export default css`
 
   .toolbar button {
     cursor: pointer;
+	align-items: center; 						
     fill: var(--lottie-player-toolbar-icon-color);
     display: flex;
     background: none;
@@ -155,6 +165,10 @@ export default css`
     background: var(--lottie-player-seeker-track-color);
   }
 
+.seeker:focus{
+	outline: 1px dotted var(--lottie-player-toolbar-icon-hover-color);
+	outline-offset: 2px;
+ }			   
   .error {
     display: flex;
     justify-content: center;

--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -105,12 +105,6 @@ export class LottiePlayer extends LitElement {
   public autoplay: boolean = false;
 
   /**
-   * Background color.
-   */
-  @property({ type: String, reflect: true })
-  public background?: string = "transparent";
-
-  /**
    * Show controls.
    */
   @property({ type: Boolean })
@@ -509,7 +503,7 @@ export class LottiePlayer extends LitElement {
   }
 
   public render(): TemplateResult | void {
-    const className: string = this.controls ? "main controls" : "main";
+    const className: string = this.controls ? "animation-wrapper controls" : "animation-wrapper";
     const animationClass: string = this.controls
       ? "animation controls"
       : "animation";
@@ -524,7 +518,6 @@ export class LottiePlayer extends LitElement {
       <div
         id="animation"
         class=${animationClass}
-        style="background:${this.background};"
       >
         ${this.currentState === PlayerState.Error
           ? html`<div class="error">⚠️</div>`
@@ -577,15 +570,13 @@ export class LottiePlayer extends LitElement {
     return html`
       <div
         id="lottie-controls"
-        aria-label="lottie-animation-controls"
         class="toolbar"
       >
         <button
           id="lottie-play-button"
           @click=${this.togglePlay}
           class=${isPlaying || isPaused ? "active" : ""}
-          style="align-items:center;"
-          tabindex="0"
+		  aria-pressed=${isPlaying || isPaused ? "true" : "false"}
           aria-label="play-pause"
         >
           ${isPlaying
@@ -612,8 +603,6 @@ export class LottiePlayer extends LitElement {
           id="lottie-stop-button"
           @click=${this.stop}
           class=${isStopped ? "active" : ""}
-          style="align-items:center;"
-          tabindex="0"
           aria-label="stop"
         >
           <svg width="24" height="24" aria-hidden="true" focusable="false">
@@ -640,15 +629,13 @@ export class LottiePlayer extends LitElement {
           aria-valuemax="100"
           role="slider"
           aria-valuenow=${this.seeker}
-          tabindex="0"
-          aria-label="lottie-seek-input"
+          aria-label="playback-bar"
         />
         <button
           id="lottie-loop-toggle"
           @click=${this.toggleLooping}
           class=${this.loop ? "active" : ""}
-          style="align-items:center;"
-          tabindex="0"
+		  aria-pressed=${this.loop ? "true" : "false"}
           aria-label="loop-toggle"
         >
           <svg width="24" height="24" aria-hidden="true" focusable="false">


### PR DESCRIPTION
Hey !
On this pull request I do 3 modifications : 
1) Few accessibility tools report the use of "background" attribut on the lottie-player tag as a main criteria failure.
([RGAA Criteria 10.1](https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#topic10)) 
To fix it, I remove the "background" attribut and I create a CSS var instead. (If you would like to keep it as attribut, can you rename it as data-background or something similar)
2) I also have a warning with the use of  "tabindex=0" attribut on button/input element because they are already focusable. So I remove them.
3) The last one is more a code quality warning with the presence of inline style. So I move them to the CSS file.
Thanks