### PR TITLE
fix(a11y): Error with ScreenReader

### DIFF
--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -517,14 +517,13 @@ export class LottiePlayer extends LitElement {
     return html` <div
       id="animation-container"
       class=${className}
-      lang="en"
-      aria-label=${this.description}
-      role="img"
     >
       <div
         id="animation"
         class=${animationClass}
         style="background:${this.background};"
+		aria-label=${this.description}
+        role="img"
       >
         ${this.currentState === PlayerState.Error
           ? html`<div class="error">⚠️</div>`
@@ -577,8 +576,8 @@ export class LottiePlayer extends LitElement {
     return html`
       <div
         id="lottie-controls"
-        aria-label="lottie-animation-controls"
         class="toolbar"
+		lang="en"
       >
         <button
           id="lottie-play-button"
@@ -641,7 +640,7 @@ export class LottiePlayer extends LitElement {
           role="slider"
           aria-valuenow=${this.seeker}
           tabindex="0"
-          aria-label="lottie-seek-input"
+          aria-label="playback bar"
         />
         <button
           id="lottie-loop-toggle"


### PR DESCRIPTION
Hey !
I have few issue using Lottie with Screen Reader.
Attribut role="img" and aria-label on #animation-container tag give some conflict with lottie control elements.
All descendants of a role="img" are presentational so it's a non-sens to have control elements inside ([more info on role="img"](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#all_descendants_are_presentational))
To fix this issue, I move some attributs from #animation-container to childs elements.

Can you also force an "aria-hidden=true" on the [#animation > svg] ?
Thx